### PR TITLE
Update midi-trigger.ttl

### DIFF
--- a/midi-trigger.ttl
+++ b/midi-trigger.ttl
@@ -1,5 +1,6 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
 @prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
 @prefix lv2atom: <http://lv2plug.in/ns/ext/atom#>.
 @prefix lv2midi: <http://lv2plug.in/ns/ext/midi#>.


### PR DESCRIPTION
Looks to be needed to instantiate the plugin.
If not, I'm getting:
```
$ jalv.gtk https://github.com/metachronica/audio-dsp-midi-trigger
Plugin:       https://github.com/metachronica/audio-dsp-midi-trigger
error: failed to expand CURIE `foaf:name'
error: /usr/lib/lv2/midi-trigger.lv2/midi-trigger.ttl:14:34: expected `]', not `,'
lilv_world_load_file(): error: Error loading file `file:///usr/lib/lv2/midi-trigger.lv2/midi-trigger.ttl'
No appropriate UI found
JACK Name:    MIDI Trigger
Block length: 256 frames
MIDI buffers: 32768 bytes
Comm buffers: 524288 bytes
Update rate:  25,0 Hz
Failed to instantiate plugin.
```